### PR TITLE
Add missing git config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     working_directory: ~/website
     steps:
       - checkout
-      - run: git config --global user.email "krzystof.zuraw@fastmail.com" && git config --global user.name "Krzysztof Żuraw"
+      - run: git config --global user.email "krzysztofzuraw@fastmail.com" && git config --global user.name "Krzysztof Żuraw"
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
@@ -22,4 +22,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - deploy
+      - deploy:
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
It turns out that we need to set up git email & username manually. This pr does that. You can see outupt here: https://circleci.com/gh/WrocTypeScript/website/10?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link