### PR TITLE
💄  Make sponsor logos 100% opaque on focus

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
     <title>Wrocław TypeScript</title>
 
     <link rel="stylesheet" href="./styles.scss" />
-    <link rel="stylesheet" href="https://use.typekit.net/sqd5uoa.css">
+    <link rel="stylesheet" href="https://use.typekit.net/sqd5uoa.css" />
   </head>
 
   <body>
@@ -111,17 +111,17 @@
     <section class="sponsors">
       <span>Supported and sponsored by</span>
       <article class="sponsors__logos-grid">
-        <a href="https://www.centra.com">
-          <img class="sponsors__logo" src="./sponsors/centra-white-long.svg" />
+        <a class="sponsors__logo" href="https://www.centra.com">
+          <img src="./sponsors/centra-white-long.svg" />
         </a>
-        <a href="https://www.youngskilled.com">
-          <img
-            class="sponsors__logo sponsors__logo--young-skilled"
-            src="./sponsors/young-skilled-inverted.svg"
-          />
+        <a
+          class="sponsors__logo sponsors__logo--young-skilled"
+          href="https://www.youngskilled.com"
+        >
+          <img src="./sponsors/young-skilled-inverted.svg" />
         </a>
-        <a href="https://www.ingrid.com">
-          <img class="sponsors__logo" src="./sponsors/ingrid.svg" />
+        <a class="sponsors__logo" href="https://www.ingrid.com">
+          <img src="./sponsors/ingrid.svg" />
         </a>
       </article>
     </section>
@@ -129,26 +129,22 @@
       <section class="footer__main">
         <article class="footer__logo">Wrocław TypeScript</article>
         <article class="social-icons">
-          <a class="icon-twitter" href="https://twitter.com/WrocTypeScript"
-            ><img src="social/icon-twitter.svg"
-          /></a>
-          <a href="https://www.facebook.com/WrocTypeScript/"
-            ><img src="social/icon-facebook.svg"
-          /></a>
-          <a href="https://www.instagram.com/wroctypescript/"
-            ><img src="social/icon-instagram.svg"
-          /></a>
-          <a href="https://github.com/wroctypescript/"
-            ><img src="social/icon-github.svg"
-          /></a>
+          <a class="icon-twitter" href="https://twitter.com/WrocTypeScript">
+            <img src="social/icon-twitter.svg" />
+          </a>
+          <a href="https://www.facebook.com/WrocTypeScript/">
+            <img src="social/icon-facebook.svg" />
+          </a>
+          <a href="https://www.instagram.com/wroctypescript/">
+            <img src="social/icon-instagram.svg" />
+          </a>
+          <a href="https://github.com/wroctypescript/">
+            <img src="social/icon-github.svg" />
+          </a>
         </article>
       </section>
       <nav class="footer__nav">
-        <a
-          href="mailto:hello@typescript.community"
-        >
-          Contact us</a
-        >
+        <a href="mailto:hello@typescript.community">Contact us</a>
         <a
           href="https://github.com/WrocTypeScript/talks/new/master?filename=new/my-talk-title.md&message=Initial%20draft&value=---%0D%0AYour+name%3A%0D%0ATarget+audience+%28beginner%2Fintermediate%2Fadvanced%29%3A%0D%0AEstimated+duration%3A%0D%0ATags%3A%0D%0A---%0D%0A%0D%0A%23+%28Title+of+your+talk%29%0D%0A%0D%0A%3C%21--+If+you+need+a+Table+of+Contents%2C+put+it+between+these+tags.+--%3E%0D%0A%3C%21--+TOC+depthFrom%3A2+depthTo%3A3+--%3E%0D%0A%0D%0A%3C%21--+%2FTOC+--%3E%0D%0A%0D%0A%23%23+The+talk%0D%0A%0D%0A%23%23%23+Summary%0D%0A%0D%0A%3C%21--+One-sentence+description+of+what+are+you+going+to+present.+--%3E%0D%0A%0D%0A%23%23%23+Format%0D%0A%0D%0A%3C%21--+Is+it+a+case+study%2C+a+live+coding+session%2C+a+workshop+or+something+else%3F+--%3E%0D%0A%0D%0A%23%23%23+Full+description%0D%0A%0D%0A%3C%21--+Be+as+verbose+as+you+like.+--%3E%0D%0A%0D%0A%23%23+You%0D%0A%0D%0A%23%23%23+How+would+you+like+to+be+announced%3F%0D%0A%0D%0A%3C%21--+A+few+words+about+yourself.+We+want+to+announce+you+properly%21+--%3E%0D%0A%0D%0A%23%23%23+Would+you+be+willing+to+have+a+Q%2FA+session+after+the+talk%3F%0D%0A%0D%0A%23%23%23+Is+there+anything+we+can+help+you+with%3F%0D%0A%0D%0A%3C%21--+Do+you+need+assistance+of+any+kind%3F+--%3E%0D%0A"
         >

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,7 +16,8 @@ body {
 body {
   margin: 0;
 
-  font-family: freight-sans-pro, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif;
+  font-family: freight-sans-pro, -apple-system, BlinkMacSystemFont, Segoe UI,
+    Helvetica, Arial, sans-serif;
   font-weight: 400;
   font-size: 2vmax;
 
@@ -228,19 +229,24 @@ h1 {
 
 .sponsors__logo {
   @extend .semi-transparent;
-  margin: 40px 0;
-  height: 50px;
 
-  @media (min-width: 400px) {
-    height: 60px;
+  > img {
+    margin: 40px 0;
+    height: 50px;
+
+    @media (min-width: 400px) {
+      height: 60px;
+    }
   }
 
   &.sponsors__logo--young-skilled {
-    height: 80px;
-    @media (min-width: 400px) {
-      height: 90px;
+    > img {
+      height: 80px;
+      @media (min-width: 400px) {
+        height: 90px;
+      }
+      margin: 0;
     }
-    margin: 0;
   }
 }
 


### PR DESCRIPTION
Tweaked .sponsor__logo class and moved it from images to anchors.

![sponsor-logo-focus](https://user-images.githubusercontent.com/15332326/49110299-65fa1980-f28d-11e8-8c63-81fcb7d38a50.png)